### PR TITLE
Add miniboxed versions of artifacts.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,8 @@ scalacOptions ++= (
   Nil
 )
 
+resolvers in ThisBuild += Resolver.sonatypeRepo("snapshots")
+
 // publishing/release details follow
 
 publishMavenStyle := true

--- a/core-minibox/build.sbt
+++ b/core-minibox/build.sbt
@@ -1,0 +1,3 @@
+name := "algebra-miniboxed"
+
+Publish.settings

--- a/core-minibox/src/main/scala_spec/algebra/spec/package.scala
+++ b/core-minibox/src/main/scala_spec/algebra/spec/package.scala
@@ -1,0 +1,14 @@
+package algebra
+
+import scala.Specializable._
+
+package object spec {
+  type _miniboxed = miniboxed
+}
+
+package spec {
+  class _specialized(group: SpecializedGroup) extends scala.annotation.StaticAnnotation {
+    def this(types: Specializable*) = this(new scala.Specializable.Group(types.toList))
+    def this() = this(Primitives)
+  }
+}

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,1 +1,3 @@
 name := "algebra"
+
+Publish.settings

--- a/core/src/main/scala/algebra/BoundedSemilattice.scala
+++ b/core/src/main/scala/algebra/BoundedSemilattice.scala
@@ -2,9 +2,7 @@ package algebra
 
 import lattice.{ BoundedMeetSemilattice, BoundedJoinSemilattice }
 
-import scala.{specialized => sp}
-
-trait BoundedSemilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semilattice[A] with CommutativeMonoid[A] { self =>
+trait BoundedSemilattice[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semilattice[A] with CommutativeMonoid[A] { self =>
 
   override def asMeetSemilattice: BoundedMeetSemilattice[A] =
     new BoundedMeetSemilattice[A] {
@@ -25,5 +23,5 @@ object BoundedSemilattice {
   /**
    * Access an implicit `BoundedSemilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedSemilattice[A]): BoundedSemilattice[A] = ev
+  @inline final def apply[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedSemilattice[A]): BoundedSemilattice[A] = ev
 }

--- a/core/src/main/scala/algebra/CommutativeGroup.scala
+++ b/core/src/main/scala/algebra/CommutativeGroup.scala
@@ -1,11 +1,9 @@
 package algebra
 
-import scala.{ specialized => sp }
-
 /**
  * An abelian group is a group whose operation is commutative.
  */
-trait CommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Group[A] with CommutativeMonoid[A]
+trait CommutativeGroup[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Group[A] with CommutativeMonoid[A]
 
 object CommutativeGroup extends GroupFunctions {
 

--- a/core/src/main/scala/algebra/CommutativeMonoid.scala
+++ b/core/src/main/scala/algebra/CommutativeMonoid.scala
@@ -1,13 +1,11 @@
 package algebra
 
-import scala.{ specialized => sp }
-
 /**
  * CommutativeMonoid represents a commutative monoid.
  * 
  * A monoid is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CommutativeMonoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] with CommutativeSemigroup[A]
+trait CommutativeMonoid[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] with CommutativeSemigroup[A]
 
 object CommutativeMonoid extends MonoidFunctions {
 

--- a/core/src/main/scala/algebra/CommutativeSemigroup.scala
+++ b/core/src/main/scala/algebra/CommutativeSemigroup.scala
@@ -1,13 +1,11 @@
 package algebra
 
-import scala.{ specialized => sp }
-
 /**
  * CommutativeSemigroup represents a commutative semigroup.
  * 
  * A semigroup is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CommutativeSemigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
+trait CommutativeSemigroup[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
 
   /**
    * CommutativeSemigroup is guaranteed to be commutative.

--- a/core/src/main/scala/algebra/Eq.scala
+++ b/core/src/main/scala/algebra/Eq.scala
@@ -1,13 +1,11 @@
 package algebra
 
-import scala.{specialized => sp}
-
 /**
  * A type class used to determine equality between 2 instances of the same
  * type. Any 2 instances `x` and `y` are equal if `eqv(x, y)` is `true`.
  * Moreover, `eqv` should form an equivalence relation.
  */
-trait Eq[@sp A] extends Any { self =>
+trait Eq[@mb @sp A] extends Any { self =>
 
   /**
    * Returns `true` if `x` and `y` are equivalent, `false` otherwise.
@@ -23,7 +21,7 @@ trait Eq[@sp A] extends Any { self =>
    * Constructs a new `Eq` instance for type `B` where 2 elements are
    * equivalent iff `eqv(f(x), f(y))`.
    */
-  def on[@sp B](f: B => A): Eq[B] =
+  def on[@mb @sp B](f: B => A): Eq[B] =
     new Eq[B] {
       def eqv(x: B, y: B): Boolean = self.eqv(f(x), f(x))
     }
@@ -48,7 +46,7 @@ object Eq extends EqFunctions {
    * Convert an implicit `Eq[A]` to an `Eq[B]` using the given
    * function `f`.
    */
-  def by[@sp A, @sp B](f: A => B)(implicit ev: Eq[B]): Eq[A] =
+  def by[@mb @sp A, @mb @sp B](f: A => B)(implicit ev: Eq[B]): Eq[A] =
     new Eq[A] {
       def eqv(x: A, y: A): Boolean = ev.eqv(f(x), f(y))
     }

--- a/core/src/main/scala/algebra/Group.scala
+++ b/core/src/main/scala/algebra/Group.scala
@@ -1,11 +1,9 @@
 package algebra
 
-import scala.{ specialized => sp }
-
 /**
  * A group is a monoid where each element has an inverse.
  */
-trait Group[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] {
+trait Group[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Monoid[A] {
 
   /**
    * Find the inverse of `a`.
@@ -33,9 +31,9 @@ trait Group[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Monoi
 }
 
 trait GroupFunctions extends MonoidFunctions {
-  def inverse[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Group[A]): A =
+  def inverse[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Group[A]): A =
     ev.inverse(a)
-  def remove[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: Group[A]): A =
+  def remove[@mb @sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: Group[A]): A =
     ev.remove(x, y)
 }
 

--- a/core/src/main/scala/algebra/Monoid.scala
+++ b/core/src/main/scala/algebra/Monoid.scala
@@ -1,14 +1,12 @@
 package algebra
 
-import scala.{ specialized => sp }
-
 /**
  * A monoid is a semigroup with an identity. A monoid is a specialization of a
  * semigroup, so its operation must be associative. Additionally,
  * `combine(x, empty) == combine(empty, x) == x`. For example, if we have `Monoid[String]`,
  * with `combine` as string concatenation, then `empty = ""`.
  */
-trait Monoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
+trait Monoid[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
 
   /**
    * Return the identity element for this monoid.
@@ -36,10 +34,10 @@ trait Monoid[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any 
 }
 
 trait MonoidFunctions extends SemigroupFunctions {
-  def empty[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: Monoid[A]): A =
+  def empty[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: Monoid[A]): A =
     ev.empty
 
-  def combineAll[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: Monoid[A]): A =
+  def combineAll[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: Monoid[A]): A =
     ev.combineAll(as)
 }
 

--- a/core/src/main/scala/algebra/Order.scala
+++ b/core/src/main/scala/algebra/Order.scala
@@ -1,7 +1,5 @@
 package algebra
 
-import scala.{specialized => sp}
-
 /**
  * The `Order` type class is used to define a total ordering on some type `A`.
  * An order is defined by a relation <=, which obeys the following laws:
@@ -19,7 +17,7 @@ import scala.{specialized => sp}
  * 
  * By the totality law, x <= y and y <= x cannot be both false.
  */
-trait Order[@sp A] extends Any with PartialOrder[A] { self =>
+trait Order[@mb @sp A] extends Any with PartialOrder[A] { self =>
 
   /**
    * Result of comparing `x` with `y`. Returns an Int whose sign is:
@@ -45,7 +43,7 @@ trait Order[@sp A] extends Any with PartialOrder[A] { self =>
    * Defines an order on `B` by mapping `B` to `A` using `f` and using `A`s
    * order to order `B`.
    */
-  override def on[@sp B](f: B => A): Order[B] =
+  override def on[@mb @sp B](f: B => A): Order[B] =
     new Order[B] {
       def compare(x: B, y: B): Int = self.compare(f(x), f(y))
     }
@@ -98,25 +96,25 @@ trait Order[@sp A] extends Any with PartialOrder[A] { self =>
 }
 
 trait OrderFunctions {
-  def compare[@sp A](x: A, y: A)(implicit ev: Order[A]): Int =
+  def compare[@mb @sp A](x: A, y: A)(implicit ev: Order[A]): Int =
     ev.compare(x, y)
 
-  def eqv[@sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
+  def eqv[@mb @sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
     ev.eqv(x, y)
-  def neqv[@sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
+  def neqv[@mb @sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
     ev.neqv(x, y)
-  def gt[@sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
+  def gt[@mb @sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
     ev.gt(x, y)
-  def gteqv[@sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
+  def gteqv[@mb @sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
     ev.gteqv(x, y)
-  def lt[@sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
+  def lt[@mb @sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
     ev.lt(x, y)
-  def lteqv[@sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
+  def lteqv[@mb @sp A](x: A, y: A)(implicit ev: Order[A]): Boolean =
     ev.lteqv(x, y)
 
-  def min[@sp A](x: A, y: A)(implicit ev: Order[A]): A =
+  def min[@mb @sp A](x: A, y: A)(implicit ev: Order[A]): A =
     ev.min(x, y)
-  def max[@sp A](x: A, y: A)(implicit ev: Order[A]): A =
+  def max[@mb @sp A](x: A, y: A)(implicit ev: Order[A]): A =
     ev.max(x, y)
 }
 
@@ -131,13 +129,13 @@ object Order extends OrderFunctions {
    * Convert an implicit `Order[A]` to an `Order[B]` using the given
    * function `f`.
    */
-  def by[@sp A, @sp B](f: A => B)(implicit ev: Order[B]): Order[A] =
+  def by[@mb @sp A, @mb @sp B](f: A => B)(implicit ev: Order[B]): Order[A] =
     ev.on(f)
 
   /**
    * Define an `Order[A]` using the given function `f`.
    */
-  def from[@sp A](f: (A, A) => Int): Order[A] =
+  def from[@mb @sp A](f: (A, A) => Int): Order[A] =
     new Order[A] {
       def compare(x: A, y: A) = f(x, y)
     }

--- a/core/src/main/scala/algebra/PartialOrder.scala
+++ b/core/src/main/scala/algebra/PartialOrder.scala
@@ -1,7 +1,5 @@
 package algebra
 
-import scala.{specialized => sp}
-
 /**
  * The `PartialOrder` type class is used to define a partial ordering on some type `A`.
  * 
@@ -21,7 +19,7 @@ import scala.{specialized => sp}
  * true      false       = -1.0    (corresponds to x < y)
  * false     true        = 1.0     (corresponds to x > y)
  */
-trait PartialOrder[@sp A] extends Any with Eq[A] { self =>
+trait PartialOrder[@mb @sp A] extends Any with Eq[A] { self =>
 
   /**
    * Result of comparing `x` with `y`. Returns NaN if operands are not
@@ -70,7 +68,7 @@ trait PartialOrder[@sp A] extends Any with Eq[A] { self =>
    * Defines a partial order on `B` by mapping `B` to `A` using `f`
    * and using `A`s order to order `B`.
    */
-  override def on[@sp B](f: B => A): PartialOrder[B] =
+  override def on[@mb @sp B](f: B => A): PartialOrder[B] =
     new PartialOrder[B] {
       def partialCompare(x: B, y: B): Double = self.partialCompare(f(x), f(y))
     }
@@ -113,25 +111,25 @@ trait PartialOrder[@sp A] extends Any with Eq[A] { self =>
 
 trait PartialOrderFunctions {
 
-  def partialCompare[@sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Double =
+  def partialCompare[@mb @sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Double =
     ev.partialCompare(x, y)
-  def tryCompare[@sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Option[Int] =
+  def tryCompare[@mb @sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Option[Int] =
     ev.tryCompare(x, y)
 
-  def pmin[@sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Option[A] =
+  def pmin[@mb @sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Option[A] =
     ev.pmin(x, y)
-  def pmax[@sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Option[A] =
+  def pmax[@mb @sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Option[A] =
     ev.pmax(x, y)
 
-  def eqv[@sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Boolean =
+  def eqv[@mb @sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Boolean =
     ev.eqv(x, y)
-  def lteqv[@sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Boolean =
+  def lteqv[@mb @sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Boolean =
     ev.lteqv(x, y)
-  def lt[@sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Boolean =
+  def lt[@mb @sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Boolean =
     ev.lt(x, y)
-  def gteqv[@sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Boolean =
+  def gteqv[@mb @sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Boolean =
     ev.gteqv(x, y)
-  def gt[@sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Boolean =
+  def gt[@mb @sp A](x: A, y: A)(implicit ev: PartialOrder[A]): Boolean =
     ev.gt(x, y)
 }
 
@@ -146,13 +144,13 @@ object PartialOrder extends PartialOrderFunctions {
    * Convert an implicit `PartialOrder[A]` to an `PartialOrder[B]`
    * using the given function `f`.
    */
-  def by[@sp A, @sp B](f: A => B)(implicit ev: PartialOrder[B]): PartialOrder[A] =
+  def by[@mb @sp A, @mb @sp B](f: A => B)(implicit ev: PartialOrder[B]): PartialOrder[A] =
     ev.on(f)
 
   /**
    * Define a `PartialOrder[A]` using the given function `f`.
    */
-  def from[@sp A](f: (A, A) => Double): PartialOrder[A] =
+  def from[@mb @sp A](f: (A, A) => Double): PartialOrder[A] =
     new PartialOrder[A] {
       def partialCompare(x: A, y: A) = f(x, y)
     }

--- a/core/src/main/scala/algebra/Semigroup.scala
+++ b/core/src/main/scala/algebra/Semigroup.scala
@@ -1,12 +1,11 @@
 package algebra
 
-import scala.{ specialized => sp }
 import scala.annotation.{ switch, tailrec }
 
 /**
  * A semigroup is any set `A` with an associative operation (`combine`).
  */
-trait Semigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any {
+trait Semigroup[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any {
 
   /**
    * Associative operation taking which combines two values.
@@ -49,19 +48,19 @@ trait Semigroup[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends A
 }
 
 trait SemigroupFunctions {
-  def combine[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: Semigroup[A]): A =
+  def combine[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: Semigroup[A]): A =
     ev.combine(x, y)
 
-  def maybeCombine[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](ox: Option[A], y: A)(implicit ev: Semigroup[A]): A =
+  def maybeCombine[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](ox: Option[A], y: A)(implicit ev: Semigroup[A]): A =
     ox match {
       case Some(x) => ev.combine(x, y)
       case None => y
     }
 
-  def combineN[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: Semigroup[A]): A =
+  def combineN[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: Semigroup[A]): A =
     ev.combineN(a, n)
 
-  def combineAllOption[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: Semigroup[A]): Option[A] =
+  def combineAllOption[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: Semigroup[A]): Option[A] =
     ev.combineAllOption(as)
 }
 

--- a/core/src/main/scala/algebra/Semilattice.scala
+++ b/core/src/main/scala/algebra/Semilattice.scala
@@ -2,14 +2,12 @@ package algebra
 
 import lattice.{ MeetSemilattice, JoinSemilattice }
 
-import scala.{specialized => sp}
-
 
 /**
  * Semilattices are commutative semigroups whose operation
  * (i.e. combine) is also idempotent.
  */
-trait Semilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with CommutativeSemigroup[A] { self =>
+trait Semilattice[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with CommutativeSemigroup[A] { self =>
 
   /**
    * Given Eq[A], return a PartialOrder[A] using the `combine`
@@ -69,5 +67,5 @@ object Semilattice {
   /**
    * Access an implicit `Semilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: Semilattice[A]): Semilattice[A] = ev
+  @inline final def apply[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: Semilattice[A]): Semilattice[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/Bool.scala
+++ b/core/src/main/scala/algebra/lattice/Bool.scala
@@ -1,8 +1,6 @@
 package algebra
 package lattice
 
-import scala.{specialized => sp}
-
 /**
  * Boolean algebras are Heyting algebras with the additional
  * constraint that the law of the excluded middle is true
@@ -22,13 +20,13 @@ import scala.{specialized => sp}
  * Every boolean algebras has a dual algebra, which involves reversing
  * true/false as well as and/or.
  */
-trait Bool[@sp(Boolean, Byte, Short, Int, Long) A] extends Any with Heyting[A] {
+trait Bool[@mb @sp(Boolean, Byte, Short, Int, Long) A] extends Any with Heyting[A] {
   def imp(a: A, b: A): A = or(complement(a), b)
 
   def dual: Bool[A] = new DualBool(this)
 }
 
-class DualBool[@sp(Boolean, Byte, Short, Int, Long) A](orig: Bool[A]) extends Bool[A] {
+class DualBool[@mb @sp(Boolean, Byte, Short, Int, Long) A](orig: Bool[A]) extends Bool[A] {
   def one: A = orig.zero
   def zero: A = orig.one
   def and(a: A, b: A): A = orig.or(a, b)
@@ -45,15 +43,15 @@ class DualBool[@sp(Boolean, Byte, Short, Int, Long) A](orig: Bool[A]) extends Bo
 }
 
 trait BoolFunctions {
-  def dual[@sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): Bool[A] =
+  def dual[@mb @sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): Bool[A] =
     ev.dual
-  def xor[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def xor[@mb @sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.xor(x, y)
-  def nand[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def nand[@mb @sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.nand(x, y)
-  def nor[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def nor[@mb @sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.nor(x, y)
-  def nxor[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def nxor[@mb @sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.nxor(x, y)
 }
 
@@ -62,5 +60,5 @@ object Bool extends HeytingFunctions with BoolFunctions {
   /**
    * Access an implicit `Bool[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): Bool[A] = ev
+  @inline final def apply[@mb @sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): Bool[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/BoundedJoinSemilattice.scala
+++ b/core/src/main/scala/algebra/lattice/BoundedJoinSemilattice.scala
@@ -1,9 +1,7 @@
 package algebra
 package lattice
 
-import scala.{specialized => sp}
-
-trait BoundedJoinSemilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with JoinSemilattice[A] { self =>
+trait BoundedJoinSemilattice[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with JoinSemilattice[A] { self =>
   def zero: A
   def isZero(a: A)(implicit ev: Eq[A]): Boolean = ev.eqv(a, zero)
 
@@ -19,5 +17,5 @@ object BoundedJoinSemilattice {
   /**
    * Access an implicit `BoundedJoinSemilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedJoinSemilattice[A]): BoundedJoinSemilattice[A] = ev
+  @inline final def apply[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedJoinSemilattice[A]): BoundedJoinSemilattice[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/BoundedLattice.scala
+++ b/core/src/main/scala/algebra/lattice/BoundedLattice.scala
@@ -1,8 +1,6 @@
 package algebra
 package lattice
 
-import scala.{specialized => sp}
-
 /**
  * A bounded lattice is a lattice that additionally has one element
  * that is the bottom (zero, also written as ⊥), and one element that
@@ -16,13 +14,13 @@ import scala.{specialized => sp}
  * 
  *   (0 ∨ a) = a = (1 ∧ a)
  */
-trait BoundedLattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Lattice[A] with BoundedMeetSemilattice[A] with BoundedJoinSemilattice[A]
+trait BoundedLattice[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with Lattice[A] with BoundedMeetSemilattice[A] with BoundedJoinSemilattice[A]
 
 trait BoundedLatticeFunctions {
-  def zero[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedJoinSemilattice[A]): A =
+  def zero[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedJoinSemilattice[A]): A =
     ev.zero
 
-  def one[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedMeetSemilattice[A]): A =
+  def one[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedMeetSemilattice[A]): A =
     ev.one
 }
 
@@ -31,5 +29,5 @@ object BoundedLattice extends LatticeFunctions with BoundedLatticeFunctions {
   /**
    * Access an implicit `BoundedLattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedLattice[A]): BoundedLattice[A] = ev
+  @inline final def apply[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedLattice[A]): BoundedLattice[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/BoundedMeetSemilattice.scala
+++ b/core/src/main/scala/algebra/lattice/BoundedMeetSemilattice.scala
@@ -1,9 +1,7 @@
 package algebra
 package lattice
 
-import scala.{specialized => sp}
-
-trait BoundedMeetSemilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with MeetSemilattice[A] { self =>
+trait BoundedMeetSemilattice[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with MeetSemilattice[A] { self =>
   def one: A
   def isOne(a: A)(implicit ev: Eq[A]): Boolean = ev.eqv(a, one)
 
@@ -19,5 +17,5 @@ object BoundedMeetSemilattice {
   /**
    * Access an implicit `BoundedMeetSemilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedMeetSemilattice[A]): BoundedMeetSemilattice[A] = ev
+  @inline final def apply[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: BoundedMeetSemilattice[A]): BoundedMeetSemilattice[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/Heyting.scala
+++ b/core/src/main/scala/algebra/lattice/Heyting.scala
@@ -3,8 +3,6 @@ package lattice
 
 import ring.CommutativeRing
 
-import scala.{specialized => sp}
-
 /**
  * Heyting algebras are bounded lattices that are also equipped with
  * an additional binary operation `imp` (for impliciation, also
@@ -35,7 +33,7 @@ import scala.{specialized => sp}
  * classical logic, see the boolean algebra type class implemented as
  * `Bool`.
  */
-trait Heyting[@sp(Boolean, Byte, Short, Int, Long) A] extends Any with BoundedLattice[A] { self =>
+trait Heyting[@mb @sp(Boolean, Byte, Short, Int, Long) A] extends Any with BoundedLattice[A] { self =>
   def and(a: A, b: A): A
   def meet(a: A, b: A): A = and(a, b)
 
@@ -61,17 +59,17 @@ trait Heyting[@sp(Boolean, Byte, Short, Int, Long) A] extends Any with BoundedLa
 }
 
 trait HeytingFunctions {
-  def zero[@sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): A = ev.zero
-  def one[@sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): A = ev.one
+  def zero[@mb @sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): A = ev.zero
+  def one[@mb @sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Bool[A]): A = ev.one
 
-  def complement[@sp(Boolean, Byte, Short, Int, Long) A](x: A)(implicit ev: Bool[A]): A =
+  def complement[@mb @sp(Boolean, Byte, Short, Int, Long) A](x: A)(implicit ev: Bool[A]): A =
     ev.complement(x)
 
-  def and[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def and[@mb @sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.and(x, y)
-  def or[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def or[@mb @sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.or(x, y)
-  def imp[@sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
+  def imp[@mb @sp(Boolean, Byte, Short, Int, Long) A](x: A, y: A)(implicit ev: Bool[A]): A =
     ev.imp(x, y)
 }
 
@@ -81,5 +79,5 @@ object Heyting extends HeytingFunctions {
   /**
    * Access an implicit `Heyting[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Heyting[A]): Heyting[A] = ev
+  @inline final def apply[@mb @sp(Boolean, Byte, Short, Int, Long) A](implicit ev: Heyting[A]): Heyting[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/JoinSemilattice.scala
+++ b/core/src/main/scala/algebra/lattice/JoinSemilattice.scala
@@ -1,14 +1,12 @@
 package algebra
 package lattice
 
-import scala.{specialized => sp}
-
 /**
  * A join-semilattice (or upper semilattice) is a semilattice whose
  * operation is called "join", and which can be thought of as a least
  * upper bound.
  */
-trait JoinSemilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any { self =>
+trait JoinSemilattice[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any { self =>
   def join(lhs: A, rhs: A): A
 
   def joinSemilattice: Semilattice[A] =
@@ -25,6 +23,6 @@ object JoinSemilattice {
   /**
    * Access an implicit `JoinSemilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: JoinSemilattice[A]): JoinSemilattice[A] = ev
+  @inline final def apply[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: JoinSemilattice[A]): JoinSemilattice[A] = ev
 
 }

--- a/core/src/main/scala/algebra/lattice/Lattice.scala
+++ b/core/src/main/scala/algebra/lattice/Lattice.scala
@@ -1,8 +1,6 @@
 package algebra
 package lattice
 
-import scala.{specialized => sp}
-
 /**
  * A lattice is a set `A` together with two operations (meet and
  * join). Both operations individually constitute semilattices (join-
@@ -27,13 +25,13 @@ import scala.{specialized => sp}
  *   - ∧ for meet
  *   - ∨ for join
  */
-trait Lattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with JoinSemilattice[A] with MeetSemilattice[A]
+trait Lattice[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any with JoinSemilattice[A] with MeetSemilattice[A]
 
 trait LatticeFunctions {
-  def join[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: JoinSemilattice[A]): A =
+  def join[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: JoinSemilattice[A]): A =
     ev.join(x, y)
 
-  def meet[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MeetSemilattice[A]): A =
+  def meet[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MeetSemilattice[A]): A =
     ev.meet(x, y)
 }
 
@@ -42,5 +40,5 @@ object Lattice extends LatticeFunctions {
   /**
    * Access an implicit `Lattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: Lattice[A]): Lattice[A] = ev
+  @inline final def apply[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: Lattice[A]): Lattice[A] = ev
 }

--- a/core/src/main/scala/algebra/lattice/MeetSemilattice.scala
+++ b/core/src/main/scala/algebra/lattice/MeetSemilattice.scala
@@ -1,14 +1,12 @@
 package algebra
 package lattice
 
-import scala.{specialized => sp}
-
 /**
  * A meet-semilattice (or lower semilattice) is a semilattice whose
  * operation is called "meet", and which can be thought of as a
  * greatest lower bound.
  */
-trait MeetSemilattice[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any { self =>
+trait MeetSemilattice[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A] extends Any { self =>
   def meet(lhs: A, rhs: A): A
 
   def meetSemilattice: Semilattice[A] =
@@ -25,5 +23,5 @@ object MeetSemilattice {
   /**
    * Access an implicit `MeetSemilattice[A]`.
    */
-  @inline final def apply[@sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: MeetSemilattice[A]): MeetSemilattice[A] = ev
+  @inline final def apply[@mb @sp(Boolean, Byte, Short, Int, Long, Float, Double) A](implicit ev: MeetSemilattice[A]): MeetSemilattice[A] = ev
 }

--- a/core/src/main/scala/algebra/number/IsReal.scala
+++ b/core/src/main/scala/algebra/number/IsReal.scala
@@ -1,12 +1,10 @@
 package algebra
 package number
 
-import scala.{ specialized => sp }
-
 /**
  * A simple type class for numeric types that are a subset of the reals.
  */
-trait IsReal[@sp(Byte,Short,Int,Long,Float,Double) A] extends Any with Order[A] with Signed[A] {
+trait IsReal[@mb @sp(Byte,Short,Int,Long,Float,Double) A] extends Any with Order[A] with Signed[A] {
   def ceil(a: A): A
   def floor(a: A): A
   def round(a: A): A
@@ -14,7 +12,7 @@ trait IsReal[@sp(Byte,Short,Int,Long,Float,Double) A] extends Any with Order[A] 
   def toDouble(a: A): Double
 }
 
-trait IsIntegral[@sp(Byte,Short,Int,Long) A] extends Any with IsReal[A] {
+trait IsIntegral[@mb @sp(Byte,Short,Int,Long) A] extends Any with IsReal[A] {
   def ceil(a: A): A = a
   def floor(a: A): A = a
   def round(a: A): A = a
@@ -22,15 +20,15 @@ trait IsIntegral[@sp(Byte,Short,Int,Long) A] extends Any with IsReal[A] {
 }
 
 trait IsRealFunctions {
-  def ceil[@sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): A =
+  def ceil[@mb @sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): A =
     ev.ceil(a)
-  def floor[@sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): A =
+  def floor[@mb @sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): A =
     ev.floor(a)
-  def round[@sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): A =
+  def round[@mb @sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): A =
     ev.round(a)
-  def isWhole[@sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): Boolean =
+  def isWhole[@mb @sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): Boolean =
     ev.isWhole(a)
-  def toDouble[@sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): Double =
+  def toDouble[@mb @sp(Byte,Short,Int,Long,Float,Double) A](a: A)(implicit ev: IsReal[A]): Double =
     ev.toDouble(a)
 }
 

--- a/core/src/main/scala/algebra/number/NRoot.scala
+++ b/core/src/main/scala/algebra/number/NRoot.scala
@@ -1,8 +1,6 @@
 package algebra
 package number
 
-import scala.{specialized => sp}
-
 /**
  * This is a type class for types with n-roots.
  *
@@ -19,21 +17,21 @@ import scala.{specialized => sp}
  * ideal. So, do not count on `ArithmeticException`s to save you from
  * bad arithmetic!
  */
-trait NRoot[@sp(Double,Float,Int,Long) A] {
+trait NRoot[@mb @sp(Double,Float,Int,Long) A] {
   def nroot(a: A, n: Int): A
   def sqrt(a: A): A = nroot(a, 2)
   def fpow(a: A, b: A): A
 }
 
 trait NRootFunctions {
-  def nroot[@sp(Double,Float,Int,Long) A](a: A, n: Int)(implicit ev: NRoot[A]): A =
+  def nroot[@mb @sp(Double,Float,Int,Long) A](a: A, n: Int)(implicit ev: NRoot[A]): A =
     ev.nroot(a, n)
-  def sqrt[@sp(Double,Float,Int,Long) A](a: A)(implicit ev: NRoot[A]): A =
+  def sqrt[@mb @sp(Double,Float,Int,Long) A](a: A)(implicit ev: NRoot[A]): A =
     ev.sqrt(a)
-  def fpow[@sp(Double,Float,Int,Long) A](a: A, b: A)(implicit ev: NRoot[A]): A =
+  def fpow[@mb @sp(Double,Float,Int,Long) A](a: A, b: A)(implicit ev: NRoot[A]): A =
     ev.fpow(a, b)
 }
 
 object NRoot extends NRootFunctions {
-  @inline final def apply[@sp(Int,Long,Float,Double) A](implicit ev: NRoot[A]) = ev
+  @inline final def apply[@mb @sp(Int,Long,Float,Double) A](implicit ev: NRoot[A]) = ev
 }

--- a/core/src/main/scala/algebra/number/Signed.scala
+++ b/core/src/main/scala/algebra/number/Signed.scala
@@ -3,13 +3,11 @@ package number
 
 import algebra.ring._
 
-import scala.{ specialized => sp }
-
 /**
  * A trait for things that have some notion of sign and the ability to
  * ensure something has a non-negative sign.
  */
-trait Signed[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
+trait Signed[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
 
   /**
    * Return a's sign:
@@ -40,25 +38,25 @@ trait Signed[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
 }
 
 trait SignedFunctions {
-  def sign[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Sign =
+  def sign[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Sign =
     ev.sign(a)
-  def signum[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Int =
+  def signum[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Int =
     ev.signum(a)
-  def abs[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): A =
+  def abs[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): A =
     ev.abs(a)
 
-  def isSignPositive[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignPositive[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignPositive(a)
-  def isSignZero[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignZero[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignZero(a)
-  def isSignNegative[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignNegative[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignNegative(a)
 
-  def isSignNonPositive[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignNonPositive[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignNonPositive(a)
-  def isSignNonZero[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignNonZero[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignNonZero(a)
-  def isSignNonNegative[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
+  def isSignNonNegative[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev: Signed[A]): Boolean =
     ev.isSignNonNegative(a)
 }
 

--- a/core/src/main/scala/algebra/package.scala
+++ b/core/src/main/scala/algebra/package.scala
@@ -1,4 +1,7 @@
 package object algebra {
   type Ring[A] = algebra.ring.Ring[A]
   type Field[A] = algebra.ring.Field[A]
+
+  type sp = spec._specialized
+  type mb = spec._miniboxed
 }

--- a/core/src/main/scala/algebra/ring/Additive.scala
+++ b/core/src/main/scala/algebra/ring/Additive.scala
@@ -1,10 +1,9 @@
 package algebra
 package ring
 
-import scala.{ specialized => sp }
 import scala.annotation.tailrec
 
-trait AdditiveSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
+trait AdditiveSemigroup[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
   def additive: Semigroup[A] = new Semigroup[A] {
     def combine(x: A, y: A): A = plus(x, y)
   }
@@ -35,14 +34,14 @@ trait AdditiveSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends An
     as.reduceOption(plus)
 }
 
-trait AdditiveCommutativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
+trait AdditiveCommutativeSemigroup[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
   override def additive: CommutativeSemigroup[A] = new CommutativeSemigroup[A] {
     def combine(x: A, y: A): A = plus(x, y)
   }
   override def hasCommutativeAddition: Boolean = true
 }
 
-trait AdditiveMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
+trait AdditiveMonoid[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveSemigroup[A] {
   override def additive: Monoid[A] = new Monoid[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)
@@ -67,14 +66,14 @@ trait AdditiveMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any w
     as.foldLeft(zero)(plus)
 }
 
-trait AdditiveCommutativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] with AdditiveCommutativeSemigroup[A] {
+trait AdditiveCommutativeMonoid[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] with AdditiveCommutativeSemigroup[A] {
   override def additive: CommutativeMonoid[A] = new CommutativeMonoid[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)
   }
 }
 
-trait AdditiveGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] {
+trait AdditiveGroup[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveMonoid[A] {
   override def additive: Group[A] = new Group[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)
@@ -92,7 +91,7 @@ trait AdditiveGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any wi
     else positiveSumN(negate(a), -n)
 }
 
-trait AdditiveCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveGroup[A] with AdditiveCommutativeMonoid[A] {
+trait AdditiveCommutativeGroup[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveGroup[A] with AdditiveCommutativeMonoid[A] {
   override def additive: CommutativeGroup[A] = new CommutativeGroup[A] {
     def empty = zero
     def combine(x: A, y: A): A = plus(x, y)
@@ -102,31 +101,31 @@ trait AdditiveCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] ext
 }
 
 trait AdditiveSemigroupFunctions {
-  def plus[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: AdditiveSemigroup[A]): A =
+  def plus[@mb @sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: AdditiveSemigroup[A]): A =
     ev.plus(x, y)
 
-  def sumN[@sp(Byte, Short, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: AdditiveSemigroup[A]): A =
+  def sumN[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: AdditiveSemigroup[A]): A =
     ev.sumN(a, n)
 
-  def trySum[@sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: AdditiveSemigroup[A]): Option[A] =
+  def trySum[@mb @sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: AdditiveSemigroup[A]): Option[A] =
     ev.trySum(as)
 }
 
 trait AdditiveMonoidFunctions extends AdditiveSemigroupFunctions {
-  def zero[@sp(Byte, Short, Int, Long, Float, Double) A](implicit ev: AdditiveMonoid[A]): A =
+  def zero[@mb @sp(Byte, Short, Int, Long, Float, Double) A](implicit ev: AdditiveMonoid[A]): A =
     ev.zero
 
-  def isZero[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev0: AdditiveMonoid[A], ev1: Eq[A]): Boolean =
+  def isZero[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev0: AdditiveMonoid[A], ev1: Eq[A]): Boolean =
     ev0.isZero(a)
 
-  def sum[@sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: AdditiveMonoid[A]): A =
+  def sum[@mb @sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: AdditiveMonoid[A]): A =
     ev.sum(as)
 }
 
 trait AdditiveGroupFunctions extends AdditiveMonoidFunctions {
-  def negate[@sp(Byte, Short, Int, Long, Float, Double) A](x: A)(implicit ev: AdditiveGroup[A]): A =
+  def negate[@mb @sp(Byte, Short, Int, Long, Float, Double) A](x: A)(implicit ev: AdditiveGroup[A]): A =
     ev.negate(x)
-  def minus[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: AdditiveGroup[A]): A =
+  def minus[@mb @sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: AdditiveGroup[A]): A =
     ev.minus(x, y)
 }
 

--- a/core/src/main/scala/algebra/ring/CommutativeRig.scala
+++ b/core/src/main/scala/algebra/ring/CommutativeRig.scala
@@ -1,12 +1,10 @@
 package algebra
 package ring
 
-import scala.{specialized => sp}
-
 /**
  * CommutativeRig is a Rig that is commutative under multiplication.
  */
-trait CommutativeRig[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with MultiplicativeCommutativeMonoid[A]
+trait CommutativeRig[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with MultiplicativeCommutativeMonoid[A]
 
 object CommutativeRig extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
   @inline final def apply[A](implicit r: CommutativeRig[A]): CommutativeRig[A] = r

--- a/core/src/main/scala/algebra/ring/CommutativeRing.scala
+++ b/core/src/main/scala/algebra/ring/CommutativeRing.scala
@@ -1,12 +1,10 @@
 package algebra
 package ring
 
-import scala.{specialized => sp}
-
 /**
  * CommutativeRing is a Ring that is commutative under multiplication.
  */
-trait CommutativeRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Ring[A] with CommutativeRig[A]
+trait CommutativeRing[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Ring[A] with CommutativeRig[A]
 
 object CommutativeRing extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
   @inline final def apply[A](implicit r: CommutativeRing[A]): CommutativeRing[A] = r

--- a/core/src/main/scala/algebra/ring/EuclideanRing.scala
+++ b/core/src/main/scala/algebra/ring/EuclideanRing.scala
@@ -2,7 +2,6 @@ package algebra
 package ring
 
 import scala.annotation.tailrec
-import scala.{specialized => sp}
 
 /**
  * EuclideanRing implements a Euclidean domain.
@@ -22,18 +21,18 @@ import scala.{specialized => sp}
  * This type does not provide access to the Euclidean function, but
  * only provides the quot, mod, and quotmod operators.
  */
-trait EuclideanRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with CommutativeRing[A] {
+trait EuclideanRing[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with CommutativeRing[A] {
   def mod(a: A, b: A): A
   def quot(a: A, b: A): A
   def quotmod(a: A, b: A): (A, A) = (quot(a, b), mod(a, b))
 }
 
 trait EuclideanRingFunctions extends AdditiveGroupFunctions with MultiplicativeMonoidFunctions {
-  def quot[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =
+  def quot[@mb @sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =
     ev.quot(x, y)
-  def mod[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =
+  def mod[@mb @sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): A =
     ev.mod(x, y)
-  def quotmod[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): (A, A) =
+  def quotmod[@mb @sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: EuclideanRing[A]): (A, A) =
     ev.quotmod(x, y)
 }
 

--- a/core/src/main/scala/algebra/ring/Field.scala
+++ b/core/src/main/scala/algebra/ring/Field.scala
@@ -1,12 +1,10 @@
 package algebra
 package ring
 
-import scala.{ specialized => sp }
-
 import java.lang.Double.{ isInfinite, isNaN, doubleToLongBits }
 import java.lang.Long.{ numberOfTrailingZeros }
 
-trait Field[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with EuclideanRing[A] with MultiplicativeCommutativeGroup[A] {
+trait Field[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with EuclideanRing[A] with MultiplicativeCommutativeGroup[A] {
 
   /**
    * This is implemented in terms of basic Field ops. However, this is
@@ -42,7 +40,7 @@ trait Field[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Eucli
 }
 
 trait FieldFunctions extends EuclideanRingFunctions with MultiplicativeGroupFunctions {
-  def fromDouble[@sp(Byte, Short, Int, Long, Float, Double) A](n: Double)(implicit ev: Field[A]): A =
+  def fromDouble[@mb @sp(Byte, Short, Int, Long, Float, Double) A](n: Double)(implicit ev: Field[A]): A =
     ev.fromDouble(n)
 }
 

--- a/core/src/main/scala/algebra/ring/Multiplicative.scala
+++ b/core/src/main/scala/algebra/ring/Multiplicative.scala
@@ -1,10 +1,9 @@
 package algebra
 package ring
 
-import scala.{ specialized => sp }
 import scala.annotation.tailrec
 
-trait MultiplicativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
+trait MultiplicativeSemigroup[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any {
   def multiplicative: Semigroup[A] =
     new Semigroup[A] {
       def combine(x: A, y: A): A = times(x, y)
@@ -36,14 +35,14 @@ trait MultiplicativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] exte
     as.reduceOption(times)
 }
 
-trait MultiplicativeCommutativeSemigroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
+trait MultiplicativeCommutativeSemigroup[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
   override def hasCommutativeMultiplication: Boolean = false
   override def multiplicative: CommutativeSemigroup[A] = new CommutativeSemigroup[A] {
     def combine(x: A, y: A): A = times(x, y)
   }
 }
 
-trait MultiplicativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
+trait MultiplicativeMonoid[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
   override def multiplicative: Monoid[A] = new Monoid[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)
@@ -68,14 +67,14 @@ trait MultiplicativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends
     as.foldLeft(one)(times)
 }
 
-trait MultiplicativeCommutativeMonoid[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] with MultiplicativeCommutativeSemigroup[A] {
+trait MultiplicativeCommutativeMonoid[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] with MultiplicativeCommutativeSemigroup[A] {
   override def multiplicative: CommutativeMonoid[A] = new CommutativeMonoid[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)
   }
 }
 
-trait MultiplicativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] {
+trait MultiplicativeGroup[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeMonoid[A] {
   override def multiplicative: Group[A] = new Group[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)
@@ -93,7 +92,7 @@ trait MultiplicativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends 
     else positivePow(reciprocal(a), -n)
 }
 
-trait MultiplicativeCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeGroup[A] with MultiplicativeCommutativeMonoid[A] {
+trait MultiplicativeCommutativeGroup[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with MultiplicativeGroup[A] with MultiplicativeCommutativeMonoid[A] {
   override def multiplicative: CommutativeGroup[A] = new CommutativeGroup[A] {
     def empty = one
     def combine(x: A, y: A): A = times(x, y)
@@ -103,30 +102,30 @@ trait MultiplicativeCommutativeGroup[@sp(Byte, Short, Int, Long, Float, Double) 
 }
 
 trait MultiplicativeSemigroupFunctions {
-  def times[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MultiplicativeSemigroup[A]): A =
+  def times[@mb @sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MultiplicativeSemigroup[A]): A =
     ev.times(x, y)
-  def pow[@sp(Byte, Short, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: MultiplicativeSemigroup[A]): A =
+  def pow[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: MultiplicativeSemigroup[A]): A =
     ev.pow(a, n)
 
-  def tryProduct[@sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: MultiplicativeSemigroup[A]): Option[A] =
+  def tryProduct[@mb @sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: MultiplicativeSemigroup[A]): Option[A] =
     ev.tryProduct(as)
 }
 
 trait MultiplicativeMonoidFunctions extends MultiplicativeSemigroupFunctions {
-  def one[@sp(Byte, Short, Int, Long, Float, Double) A](implicit ev: MultiplicativeMonoid[A]): A =
+  def one[@mb @sp(Byte, Short, Int, Long, Float, Double) A](implicit ev: MultiplicativeMonoid[A]): A =
     ev.one
 
-  def isOne[@sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev0: MultiplicativeMonoid[A], ev1: Eq[A]): Boolean =
+  def isOne[@mb @sp(Byte, Short, Int, Long, Float, Double) A](a: A)(implicit ev0: MultiplicativeMonoid[A], ev1: Eq[A]): Boolean =
     ev0.isOne(a)
 
-  def product[@sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: MultiplicativeMonoid[A]): A =
+  def product[@mb @sp(Byte, Short, Int, Long, Float, Double) A](as: TraversableOnce[A])(implicit ev: MultiplicativeMonoid[A]): A =
     ev.product(as)
 }
 
 trait MultiplicativeGroupFunctions extends MultiplicativeMonoidFunctions {
-  def reciprocal[@sp(Byte, Short, Int, Long, Float, Double) A](x: A)(implicit ev: MultiplicativeGroup[A]): A =
+  def reciprocal[@mb @sp(Byte, Short, Int, Long, Float, Double) A](x: A)(implicit ev: MultiplicativeGroup[A]): A =
     ev.reciprocal(x)
-  def div[@sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MultiplicativeGroup[A]): A =
+  def div[@mb @sp(Byte, Short, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: MultiplicativeGroup[A]): A =
     ev.div(x, y)
 }
 

--- a/core/src/main/scala/algebra/ring/Rig.scala
+++ b/core/src/main/scala/algebra/ring/Rig.scala
@@ -1,8 +1,7 @@
 package algebra
 package ring
 
-import annotation.tailrec
-import scala.{specialized => sp}
+import scala.annotation.tailrec
 
 /**
  * Rig consists of:
@@ -16,7 +15,7 @@ import scala.{specialized => sp}
 
  * Mnemonic: "Rig is a Ring without 'N'egation."
  */
-trait Rig[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with MultiplicativeMonoid[A]
+trait Rig[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with MultiplicativeMonoid[A]
 
 object Rig extends AdditiveMonoidFunctions with MultiplicativeMonoidFunctions {
   @inline final def apply[A](implicit ev: Rig[A]): Rig[A] = ev

--- a/core/src/main/scala/algebra/ring/Ring.scala
+++ b/core/src/main/scala/algebra/ring/Ring.scala
@@ -1,8 +1,6 @@
 package algebra
 package ring
 
-import scala.{specialized => sp}
-
 /**
  * Ring consists of:
  * 
@@ -16,7 +14,7 @@ import scala.{specialized => sp}
  * possible, these methods should be overridden by more efficient
  * implementations.
  */
-trait Ring[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with Rng[A] {
+trait Ring[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A] with Rng[A] {
 
   /**
    * Convert the given integer to an instance of A.
@@ -33,7 +31,7 @@ trait Ring[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Rig[A]
 }
 
 trait RingFunctions {
-  def fromInt[@sp(Byte, Short, Int, Long, Float, Double) A](n: Int)(implicit ev: Ring[A]): A =
+  def fromInt[@mb @sp(Byte, Short, Int, Long, Float, Double) A](n: Int)(implicit ev: Ring[A]): A =
     ev.fromInt(n)
 }
 

--- a/core/src/main/scala/algebra/ring/Rng.scala
+++ b/core/src/main/scala/algebra/ring/Rng.scala
@@ -1,8 +1,7 @@
 package algebra
 package ring
 
-import annotation.tailrec
-import scala.{specialized => sp}
+import scala.annotation.tailrec
 
 /**
  * Rng (pronounced "Rung") consists of:
@@ -16,7 +15,7 @@ import scala.{specialized => sp}
  * 
  * Mnemonic: "Rng is a Ring without multiplicative 'I'dentity."
  */
-trait Rng[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with AdditiveCommutativeGroup[A]
+trait Rng[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Semiring[A] with AdditiveCommutativeGroup[A]
 
 object Rng extends AdditiveGroupFunctions with MultiplicativeSemigroupFunctions {
   @inline final def apply[A](implicit ev: Rng[A]): Rng[A] = ev

--- a/core/src/main/scala/algebra/ring/Semiring.scala
+++ b/core/src/main/scala/algebra/ring/Semiring.scala
@@ -1,8 +1,7 @@
 package algebra
 package ring
 
-import annotation.tailrec
-import scala.{specialized => sp}
+import scala.annotation.tailrec
 
 /**
  * Semiring consists of:
@@ -17,7 +16,7 @@ import scala.{specialized => sp}
  * A Semiring with a multiplicative identity (1) is a Rig.
  * A Semiring with both of those is a Ring.
  */
-trait Semiring[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveCommutativeMonoid[A] with MultiplicativeSemigroup[A]
+trait Semiring[@mb @sp(Byte, Short, Int, Long, Float, Double) A] extends Any with AdditiveCommutativeMonoid[A] with MultiplicativeSemigroup[A]
 
 object Semiring extends AdditiveMonoidFunctions with MultiplicativeSemigroupFunctions {
   @inline final def apply[A](implicit ev: Semiring[A]): Semiring[A] = ev

--- a/core/src/main/scala_spec/algebra/spec/package.scala
+++ b/core/src/main/scala_spec/algebra/spec/package.scala
@@ -1,0 +1,10 @@
+package algebra
+
+package object spec {
+  type _specialized = scala.specialized
+}
+
+package spec {
+  class _miniboxed extends scala.annotation.StaticAnnotation
+}
+

--- a/laws/build.sbt
+++ b/laws/build.sbt
@@ -5,3 +5,5 @@ libraryDependencies ++= Seq(
   "org.typelevel" %% "discipline" % "0.2.1",
   "org.scalatest" %% "scalatest" % "2.1.3" % "test"
 )
+
+Publish.settings

--- a/project/Minibox.scala
+++ b/project/Minibox.scala
@@ -1,0 +1,21 @@
+import sbt._
+import sbt.Keys._
+
+object Minibox {
+  val version = "0.4-SNAPSHOT"
+  val miniboxing = "org.scala-miniboxing.plugins" %% "miniboxing-runtime" % version
+
+  def miniboxed(proj: Project) = Seq(
+    libraryDependencies += miniboxing,
+    addCompilerPlugin("org.scala-miniboxing.plugins" %% "miniboxing-plugin" % version),
+    unmanagedSourceDirectories in Compile ++= {
+      val projSourceDir = (sourceDirectory in (proj, Compile)).value
+      val projSpecDir = projSourceDir / "scala_spec"
+      val projUnmanagedSourceDirectories =
+        (unmanagedSourceDirectories in (proj, Compile)).value
+      (projUnmanagedSourceDirectories --- projSpecDir).get
+    },
+    unmanagedSourceDirectories in Compile +=
+      (sourceDirectory in Compile).value / s"scala_spec"
+  )
+}

--- a/project/Minibox.scala
+++ b/project/Minibox.scala
@@ -18,4 +18,8 @@ object Minibox {
     unmanagedSourceDirectories in Compile +=
       (sourceDirectory in Compile).value / s"scala_spec"
   )
+
+  def specDirectory =
+    unmanagedSourceDirectories in Compile +=
+      (sourceDirectory in Compile).value / s"scala_spec"
 }

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -15,8 +15,6 @@ import scala.xml.transform.{ RewriteRule, RuleTransformer }
 object Publish {
   lazy val preamble = Seq(
     publishMavenStyle := true,
-    publishArtifact in Test := false,
-    pomIncludeRepository := { _ => false },
     publishTo <<= version { (v: String) =>
       val nexus = "https://oss.sonatype.org/"
       if (v.trim.endsWith("SNAPSHOT"))
@@ -24,7 +22,9 @@ object Publish {
       else
         Some("releases"  at nexus + "service/local/staging/deploy/maven2")
     },
-    pomExtra := (
+    publishArtifact in Test in ThisBuild := false,
+    pomIncludeRepository in ThisBuild := { _ => false },
+    pomExtra in ThisBuild := (
     <scm>
       <url>git@github.com:non/algebra.git</url>
       <connection>scm:git:git@github.com:non/algebra.git</connection>

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,0 +1,80 @@
+import sbt._
+import sbt.Keys._
+
+import com.typesafe.sbt.pgp.PgpKeys._
+
+import sbtrelease._
+import sbtrelease.ReleasePlugin._
+import sbtrelease.ReleasePlugin.ReleaseKeys._
+import sbtrelease.ReleaseStateTransformations._
+import sbtrelease.Utilities._
+
+import scala.xml.{ Node, NodeSeq }
+import scala.xml.transform.{ RewriteRule, RuleTransformer }
+
+object Publish {
+  lazy val settings =
+    releaseSettings ++
+    Seq(
+      releaseProcess := Seq[ReleaseStep](
+        checkSnapshotDependencies,
+        inquireVersions,
+        runTest,
+        setReleaseVersion,
+        commitReleaseVersion,
+        tagRelease,
+        publishSignedArtifacts,
+        setNextVersion,
+        commitNextVersion,
+        pushChanges
+      ),
+      pomDependencyExclusions <<= pomDependencyExclusions ?? Seq(),
+      pomPostProcess := { (node: Node) =>
+        val exclusions = pomDependencyExclusions.value.toSet
+        val rule = new RewriteRule {
+          override def transform(n: Node): NodeSeq = {
+            if (n.label == "dependency") {
+              val groupId = (n \ "groupId").text
+              val artifactId = (n \ "artifactId").text
+              if (exclusions.contains(groupId -> artifactId)) {
+                NodeSeq.Empty
+              } else {
+                n
+              }
+            } else {
+              n
+            }
+          }
+        }
+        new RuleTransformer(rule).transform(node)(0)
+      }
+    )
+
+  lazy val publishSignedArtifacts = ReleaseStep(
+    action = { st =>
+      val extracted = st.extract
+      val ref = extracted.get(thisProjectRef)
+      extracted.runAggregated(publishSigned in Global in ref, st)
+    },
+    check = { st =>
+      // getPublishTo fails if no publish repository is set up.
+      val ex = st.extract
+      val ref = ex.get(thisProjectRef)
+      Classpaths.getPublishTo(ex.get(publishTo in Global in ref))
+      st
+    },
+    enableCrossBuild = true
+  )
+
+  lazy val noPublishSettings = Seq(
+    publish := (),
+    publishLocal := (),
+    publishArtifact := false
+  )
+
+  val pomDependencyExclusions =
+    SettingKey[Seq[(String, String)]](
+      "pom-dependency-exclusions",
+      "Group ID / Artifact ID dependencies to exclude from the maven POM."
+    )
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -1,5 +1,0 @@
-import sbt._
-import sbt.Keys._
-
-object AlgebraBuild extends Build {
-}

--- a/project/build.scala
+++ b/project/build.scala
@@ -2,38 +2,4 @@ import sbt._
 import sbt.Keys._
 
 object AlgebraBuild extends Build {
-
-  lazy val core =
-    Project("core", file("core"))
-      .settings(algebraSettings: _*)
-      .settings(
-        unmanagedSourceDirectories in Compile +=
-          (sourceDirectory in Compile).value / s"scala_spec"
-      )
-
-  lazy val std =
-    Project("std", file("std")).settings(algebraSettings: _*).dependsOn(core)
-
-  lazy val laws =
-    Project("laws", file("laws")).settings(algebraSettings: _*).dependsOn(core, std)
-
-  lazy val aggregate =
-    Project("aggregate", file(".")).settings(aggregateSettings: _*).dependsOn(core, std, laws)
-
-  lazy val coreMinibox =
-    Project("core-minibox", file("core-minibox"))
-      .settings(algebraSettings: _*)
-      .settings(Minibox.miniboxed(core): _*)
-
-  lazy val stdMinibox =
-    Project("std-minibox", file("std-minibox"))
-      .settings(algebraSettings: _*)
-      .settings(Minibox.miniboxed(std): _*)
-      .dependsOn(coreMinibox)
-
-  lazy val algebraSettings =
-    Defaults.defaultSettings ++ Publish.settings
-
-  lazy val aggregateSettings =
-    algebraSettings ++ Publish.noPublishSettings
 }

--- a/std-minibox/build.sbt
+++ b/std-minibox/build.sbt
@@ -1,0 +1,3 @@
+name := "algebra-std-miniboxed"
+
+Publish.settings

--- a/std/build.sbt
+++ b/std/build.sbt
@@ -1,1 +1,3 @@
 name := "algebra-std"
+
+Publish.settings


### PR DESCRIPTION
This does a source based version (use same sources, but with a minor `algebra.spec` compat layer that changes between the 2). Basically, we use 2 type aliases, `@sp` and `@mb` for specialization and miniboxing respectively. Depending on whether we are using the standard versions or the `-miniboxed` versions, we'll either stub out the `@mb` or the `@sp` annotation. So, if miniboxing is enabled, we don't specialize. If specialization is enabled, we don't minibox.

The miniboxed versions don't currently compile. @VladUreche this is failing because the typeclasses extend `Any`. Is this a known limitation or can it be fixed?

I've also taken the opportunity to clean up the build a bit.
