### PR TITLE
Simplify RingLaws: Don't pass around a Predicate, be more explicit about requiring non-zero elements.

### DIFF
--- a/laws/shared/src/main/scala/algebra/laws/GroupLaws.scala
+++ b/laws/shared/src/main/scala/algebra/laws/GroupLaws.scala
@@ -69,7 +69,7 @@ trait GroupLaws[A] extends Laws {
     parents = List(commutativeMonoid, semilattice)
   )
 
-  def group(implicit A: Group[A]) = new GroupProperties(
+  def group(implicit A: Group[A], Arb: Arbitrary[A]) = new GroupProperties(
     name = "group",
     parents = List(monoid),
     Rules.leftInverse(A.empty)(A.combine)(A.inverse),
@@ -77,7 +77,7 @@ trait GroupLaws[A] extends Laws {
     Rules.consistentInverse("remove")(A.remove)(A.combine)(A.inverse)
   )
 
-  def commutativeGroup(implicit A: CommutativeGroup[A]) = new GroupProperties(
+  def commutativeGroup(implicit A: CommutativeGroup[A], Arb: Arbitrary[A]) = new GroupProperties(
     name = "commutative group",
     parents = List(group, commutativeMonoid)
   )
@@ -109,14 +109,14 @@ trait GroupLaws[A] extends Laws {
     parents = List(additiveMonoid)
   )
 
-  def additiveGroup(implicit A: AdditiveGroup[A]) = new AdditiveProperties(
-    base = group(A.additive),
+  def additiveGroup(implicit A: AdditiveGroup[A], Arb: Arbitrary[A]) = new AdditiveProperties(
+    base = group(A.additive, Arb),
     parents = List(additiveMonoid),
     Rules.consistentInverse("subtract")(A.minus)(A.plus)(A.negate)
   )
 
-  def additiveCommutativeGroup(implicit A: AdditiveCommutativeGroup[A]) = new AdditiveProperties(
-    base = commutativeGroup(A.additive),
+  def additiveCommutativeGroup(implicit A: AdditiveCommutativeGroup[A], Arb: Arbitrary[A]) = new AdditiveProperties(
+    base = commutativeGroup(A.additive, Arb),
     parents = List(additiveGroup)
   )
 

--- a/laws/shared/src/main/scala/algebra/laws/RingLaws.scala
+++ b/laws/shared/src/main/scala/algebra/laws/RingLaws.scala
@@ -46,11 +46,12 @@ trait RingLaws[A] extends GroupLaws[A] {
   )
 
   def multiplicativeGroup(implicit A: MultiplicativeGroup[A] with AdditiveMonoid[A]) = {
-    implicit val Arb: Arbitrary[A] = nonZeroArb(A)
+    val arb: Arbitrary[A] = nonZeroArb(A)
+    val gen = arb.arbitrary
     new MultiplicativeProperties(
-      base = _.group(A.multiplicative, Arb),
+      base = _.group(A.multiplicative, arb),
       parent = Some(multiplicativeMonoid),
-      "consistent division" -> forAll{ (x: A, y: A) =>
+      "consistent division" -> forAll(gen, gen) { (x: A, y: A) =>
         (A.div(x, y) ?== A.times(x, A.reciprocal(y)))
       }
     )

--- a/laws/shared/src/main/scala/algebra/laws/package.scala
+++ b/laws/shared/src/main/scala/algebra/laws/package.scala
@@ -1,19 +1,10 @@
 package algebra
 
-import algebra.ring.AdditiveMonoid
-
-import org.typelevel.discipline.Predicate
-
 import org.scalacheck._
 import org.scalacheck.util.Pretty
 import Prop.{False, Proof, Result}
 
 package object laws {
-
-  implicit def PredicateFromMonoid[A](implicit ev: Eq[A], A: AdditiveMonoid[A]): Predicate[A] =
-    new Predicate[A] {
-      def apply(a: A) = ev.neqv(a, A.zero)
-    }
 
   lazy val proved = Prop(Result(status = Proof))
 

--- a/laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -7,7 +7,7 @@ import algebra.macros._
 import algebra.std.all._
 import algebra.std.Rat
 
-import org.typelevel.discipline.{Laws, Predicate}
+import org.typelevel.discipline.Laws
 import org.typelevel.discipline.scalatest.Discipline
 import org.scalacheck.Arbitrary
 import org.scalatest.FunSuite
@@ -24,7 +24,7 @@ trait LawTestsBase extends FunSuite with Discipline {
   implicit def logicLaws[A: Eq: Arbitrary] = LogicLaws[A]
 
   implicit def latticeLaws[A: Eq: Arbitrary] = LatticeLaws[A]
-  implicit def ringLaws[A: Eq: Arbitrary: Predicate] = RingLaws[A]
+  implicit def ringLaws[A: Eq: Arbitrary] = RingLaws[A]
   implicit def baseLaws[A: Eq: Arbitrary] = BaseLaws[A]
   implicit def latticePartialOrderLaws[A: Eq: Arbitrary] = LatticePartialOrderLaws[A]
 
@@ -52,21 +52,21 @@ trait LawTestsBase extends FunSuite with Discipline {
   laws[LogicLaws, Boolean]("bool-from-ring").check(_.bool(BooleanRing.asBool))
 
   laws[OrderLaws, String].check(_.order)
-  laws[GroupLaws, String].check(_.monoid)
+  laws[RingLaws, String].check(_.monoid)
 
   {
     // TODO: test a type that has Eq but not Order
     implicit val g: Group[Int] = Group.additive[Int]
     laws[OrderLaws, Option[Int]].check(_.order)
-    laws[GroupLaws, Option[Int]].check(_.monoid)
+    laws[RingLaws, Option[Int]].check(_.monoid)
     laws[OrderLaws, Option[String]].check(_.order)
-    laws[GroupLaws, Option[String]].check(_.monoid)
+    laws[RingLaws, Option[String]].check(_.monoid)
   }
 
   laws[OrderLaws, List[Int]].check(_.order)
-  laws[GroupLaws, List[Int]].check(_.monoid)
+  laws[RingLaws, List[Int]].check(_.monoid)
   laws[OrderLaws, List[String]].check(_.order)
-  laws[GroupLaws, List[String]].check(_.monoid)
+  laws[RingLaws, List[String]].check(_.monoid)
 
   laws[LogicLaws, Set[Byte]].check(_.generalizedBool)
   laws[RingLaws, Set[Byte]].check(_.boolRng(setBoolRng[Byte]))


### PR DESCRIPTION
Hi,

I present this PR for discussion. The goal is to simplify RingLaws, namely the case when we need a generator of non-zero values. The approach is to be more explicit about what laws require non-zero elements. I added an extra `Arbitrary[A]` argument to `group` properties and "descendants", which then allow to pass a generator of non-zero values from `multiplicativeGroup` and `multiplicativeCommutativeGroup`. `multiplicativeGroup` and `multiplicativeCommutativeGroup` now also explicitly require an instance of `AdditiveMonoid` in order to access `zero` to create non-zero generator.

I find it slightly clearer than the predicate approach. Whether you agree is up for discussion, but by the sheer number of lines saved, it is a simplification.
