### PR TITLE
Add scoverage and report results to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala: 
   - 2.11.8
   - 2.10.6
-script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test && ./sbt ++$TRAVIS_SCALA_VERSION core:mima-report-binary-issues
+script: ./sbt ++$TRAVIS_SCALA_VERSION clean coreJS/test lawsJS/test && ./sbt ++$TRAVIS_SCALA_VERSION clean coverage coreJVM/test lawsJVM/test coverageReport && ./sbt ++$TRAVIS_SCALA_VERSION core:mima-report-binary-issues
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 sudo: false
 language: scala
-matrix:
-  include:
-    - scala: 2.10.6
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean compile test && ./sbt ++$TRAVIS_SCALA_VERSION core:mima-report-binary-issues
-
-    - scala: 2.11.8
-      script: ./sbt ++$TRAVIS_SCALA_VERSION clean compile test && ./sbt ++$TRAVIS_SCALA_VERSION core:mima-report-binary-issues
+scala: 
+  - 2.11.8
+  - 2.10.6
+script: ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test && ./sbt ++$TRAVIS_SCALA_VERSION core:mima-report-binary-issues
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
 notifications:
   irc:
     channels:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![Build Status](https://api.travis-ci.org/non/algebra.png)](https://travis-ci.org/non/algebra/)
+[![Build Status](https://api.travis-ci.org/typelevel/algebra.png)](https://travis-ci.org/typelevel/algebra/)
+[![Coverage status](https://img.shields.io/codecov/c/github/typelevel/algebra/master.svg)](https://codecov.io/github/typelevel/algebra)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/non/algebra?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.spire-math/algebra_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.spire-math/algebra_2.11)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.typelevel/algebra_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.spire-math/algebra_2.11)
 
 # algebra
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val docSettings = Seq(
   autoAPIMappings := true,
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(coreJVM, lawsJVM),
   site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "api"),
-  git.remoteRepo := "git@github.com:non/algebra.git"
+  git.remoteRepo := "git@github.com:typelevel/algebra.git"
 )
 
 lazy val aggregate = project.in(file("."))
@@ -112,8 +112,8 @@ lazy val publishSettings = Seq(
   },
   pomExtra := (
     <scm>
-      <url>git@github.com:non/algebra.git</url>
-      <connection>scm:git:git@github.com:non/algebra.git</connection>
+      <url>git@github.com:typelevel/algebra.git</url>
+      <connection>scm:git:git@github.com:typelevel/algebra.git</connection>
     </scm>
     <developers>
       <developer>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ addSbtPlugin("com.typesafe.sbt"  % "sbt-ghpages"     % "0.5.3")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-site"        % "0.8.1")
 addSbtPlugin("org.scala-js"      % "sbt-scalajs"     % "0.6.11")
 addSbtPlugin("com.typesafe"      % "sbt-mima-plugin" % "0.1.7")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage"   % "1.1.0")
+


### PR DESCRIPTION
I copied the setup from tixxit/delimited - I think this should just ~work. I've also updated the buttons in the README to point to typelevel/aglebra now.