### PR TITLE
(Do not merge). Added finer definitions of modulo, and related laws.

### DIFF
--- a/core/src/main/scala/algebra/instances/bigInt.scala
+++ b/core/src/main/scala/algebra/instances/bigInt.scala
@@ -10,7 +10,7 @@ trait BigIntInstances extends cats.kernel.instances.BigIntInstances {
     new BigIntAlgebra
 }
 
-class BigIntAlgebra extends EuclideanRing[BigInt] with Serializable {
+class BigIntAlgebra extends EuclideanRing[BigInt] with EuclideanFunction[BigInt] with TDivMod[BigInt] with Serializable {
 
   val zero: BigInt = BigInt(0)
   val one: BigInt = BigInt(1)
@@ -19,10 +19,20 @@ class BigIntAlgebra extends EuclideanRing[BigInt] with Serializable {
   def negate(a: BigInt): BigInt = -a
   override def minus(a: BigInt, b: BigInt): BigInt = a - b
 
+  def compare(a: BigInt, b: BigInt): Int = a.compare(b)
+  def isWhole(a: BigInt): Boolean = true
+
+  def euclideanFunction(a: BigInt): BigInt = a.abs
   def times(a: BigInt, b: BigInt): BigInt = a * b
   def quot(a: BigInt, b: BigInt) = a / b
   def mod(a: BigInt, b: BigInt) = a % b
   override def quotmod(a:BigInt, b:BigInt) = a /% b
+
+  def tmod(a: BigInt, b: BigInt): BigInt = a % b
+  def tdiv(a: BigInt, b: BigInt): BigInt = a / b
+  // TODO: override tdivmod using BigInteger.divideAndRemainder
+
+  // BigInt.mod does not obey any current law
 
   override def pow(a: BigInt, k: Int): BigInt = a pow k
 

--- a/core/src/main/scala/algebra/ring/DivMod.scala
+++ b/core/src/main/scala/algebra/ring/DivMod.scala
@@ -7,7 +7,10 @@ import scala.{specialized => sp}
 trait OrderedRing[@sp(Int, Long, Float, Double) A] extends Any with Ring[A] with Order[A] {
   def isWhole(x: A): Boolean 
   def abs(x: A): A = if (lt(x, zero)) negate(x) else x
-  def sign(x: A): Int = compare(x, zero).signum
+  def sign(x: A): Int = {
+    val c = compare(x, zero)
+    c.signum
+  }
 }
 
 /**

--- a/core/src/main/scala/algebra/ring/DivMod.scala
+++ b/core/src/main/scala/algebra/ring/DivMod.scala
@@ -1,0 +1,58 @@
+package algebra
+package ring
+
+import scala.{specialized => sp}
+
+// Temporary type class to defines convenience methods for the law tests in ordered rings
+trait OrderedRing[@sp(Int, Long, Float, Double) A] extends Any with Ring[A] with Order[A] {
+  def isWhole(x: A): Boolean 
+  def abs(x: A): A = if (lt(x, zero)) negate(x) else x
+  def sign(x: A): Int = compare(x, zero).signum
+}
+
+/**
+ * Division and modulus for computer scientists
+ * taken from https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/divmodnote-letter.pdf
+ * 
+ * For two numbers x (dividend) and y (divisor) on an ordered ring with y != 0,
+ * there exists a pair of numbers q (quotient) and r (remainder)
+ * such that these laws are satisfied:
+ * 
+ * (1) q is an integer
+ * (2) x = y * q + r (division rule)
+ * (3) |r| < |y|,
+ * (4) r = 0 or sign(r) = sign(x),
+ * 
+ * where sign is the sign function, and the absolute value 
+ * function |x| is defined as |x| = x if x >=0, and |x| = -x otherwise.
+ * 
+ * We define functions tmod and tdiv, such that:
+ * q = tdiv(x, y) and r = tmod(x, y)
+ * 
+ * Law (4) corresponds to ISO C99 and Haskell's quot/rem.
+ */
+trait TDivMod[@sp(Int, Long, Float, Double) A] extends Any with OrderedRing[A] {
+  def tmod(x: A, y: A): A
+  def tdiv(x: A, y: A): A
+  def tdivmod(x: A, y: A): (A, A) = (tdiv(x, y), tmod(x, y))
+}
+
+// missing TDivModFunctions and TDivMod companion object
+
+/**
+ * Variant of TDivMod where law (4) is replaced by:
+ * 
+ * (4) r = 0 or sign(r) = sign(y).
+ * See https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/divmodnote-letter.pdf
+ * 
+ * This convention is described by Knuth and used by Haskell,
+ * and fmod corresponds to the REM function of the IEEE floating-point
+ * standard.
+ */
+trait FDivMod[@sp(Int, Long, Float, Double) A] extends Any with OrderedRing[A] {
+  def fmod(x: A, y: A): A
+  def fdiv(x: A, y: A): A
+  def fdivmod(x: A, y: A): (A, A) = (fdiv(x, y), fmod(x, y))
+}
+
+// missing FDivModFunctions and FDivMod companion object

--- a/core/src/main/scala/algebra/ring/EuclideanRing.scala
+++ b/core/src/main/scala/algebra/ring/EuclideanRing.scala
@@ -20,6 +20,8 @@ import scala.{specialized => sp}
  * 
  * This type does not provide access to the Euclidean function, but
  * only provides the quot, mod, and quotmod operators.
+ * 
+ * The Euclidean function is available in the `EuclideanFunction` type.
  */
 trait EuclideanRing[@sp(Int, Long, Float, Double) A] extends Any with CommutativeRing[A] {
   def mod(a: A, b: A): A
@@ -38,4 +40,25 @@ trait EuclideanRingFunctions[R[T] <: EuclideanRing[T]] extends RingFunctions[R] 
 
 object EuclideanRing extends EuclideanRingFunctions[EuclideanRing] {
   @inline final def apply[A](implicit ev: EuclideanRing[A]): EuclideanRing[A] = ev
+}
+
+/**
+  * Extends EuclideanRing with a (submultiplicative) Euclidean function.
+  * 
+  * On an EuclideanRing, we can require the Euclidean function to be submultiplicative
+  * without loss of generality:
+  * 
+  *   if x, y are not zero, then f(a) <= f(ab)
+  */
+trait EuclideanFunction[@sp(Int, Long, Float, Double) A] extends Any with EuclideanRing[A] {
+  def euclideanFunction(a: A): BigInt
+}
+
+trait EuclideanFunctionFunctions[R[T] <: EuclideanFunction[T]] extends EuclideanRingFunctions[R] {
+  def euclideanFunction[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: R[A]): BigInt =
+    ev.euclideanFunction(a)
+}
+
+object EuclideanFunction extends EuclideanFunctionFunctions[EuclideanFunction] {
+  @inline final def apply[A](implicit ev: EuclideanFunction[A]): EuclideanFunction[A] = ev
 }

--- a/laws/src/main/scala/algebra/laws/RingLaws.scala
+++ b/laws/src/main/scala/algebra/laws/RingLaws.scala
@@ -146,6 +146,68 @@ trait RingLaws[A] extends GroupLaws[A] {
     }
   )
 
+  def tDivMod(implicit A: TDivMod[A]) = RingProperties.fromParent(
+    name = "tDivMod",
+    parent = ring,
+    "quotient is integer" -> forAll { (x: A, y: A) =>
+      pred(y) ==> A.isWhole(A.tdiv(x, y))
+    },
+    "remainder smaller that divisor" -> forAll { (x: A, y: A) =>
+      pred(y) ==> A.lt(A.abs(A.tmod(x, y)), A.abs(y))
+    },
+    "division rule" -> forAll { (x: A, y: A) =>
+      pred(y) ==> {
+        val (q, r) = A.tdivmod(x, y)
+        x ?== A.plus(A.times(y, q), r)
+      }
+    },
+    "sign of remainder" -> forAll { (x: A, y: A) =>
+      pred(y) ==> {
+        val signr = A.sign(A.tmod(x, y))
+        (signr == 0) || (signr == A.sign(x))
+      }
+    }
+  )
+
+  def fDivMod(implicit A: FDivMod[A]) = RingProperties.fromParent(
+    name = "fDivMod",
+    parent = ring,
+    "quotient is integer" -> forAll { (x: A, y: A) =>
+      pred(y) ==> A.isWhole(A.fdiv(x, y))
+    },
+    "remainder smaller that divisor" -> forAll { (x: A, y: A) =>
+      pred(y) ==> A.lt(A.abs(A.fmod(x, y)), A.abs(y))
+    },
+    "division rule" -> forAll { (x: A, y: A) =>
+      pred(y) ==> {
+        val (q, r) = A.fdivmod(x, y)
+        x ?== A.plus(A.times(y, q), r)
+      }
+    },
+    "sign of remainder" -> forAll { (x: A, y: A) =>
+      pred(y) ==> {
+        val signr = A.sign(A.fmod(x, y))
+        (signr == 0) || (signr == A.sign(y))
+      }
+    }
+  )
+
+  def euclideanFunction(implicit A: EuclideanFunction[A]) = RingProperties.fromParent(
+    name = "euclidean function",
+    parent = euclideanRing,
+    "euclideanFunction" -> forAll { (x: A, y: A) =>
+      pred(y) ==> {
+        val (q, r) = A.quotmod(x, y)
+        A.isZero(r) || (A.euclideanFunction(r) < A.euclideanFunction(y))
+      }
+    },
+    "submultiplicative function" -> forAll { (x: A, y: A) =>
+      (pred(x) && pred(y)) ==> {
+        A.euclideanFunction(x) <= A.euclideanFunction(A.times(x, y))
+      }
+    }
+  )
+
   // Everything below fields (e.g. rings) does not require their multiplication
   // operation to be a group. Hence, we do not check for the existence of an
   // inverse. On the other hand, fields require their multiplication to be an

--- a/laws/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/src/test/scala/algebra/laws/LawTests.scala
@@ -154,7 +154,8 @@ class LawTests extends FunSuite with Configuration with Discipline {
   laws[RingLaws, Long].check(_.euclideanRing)
   laws[LatticeLaws, Long].check(_.boundedDistributiveLattice)
 
-  laws[RingLaws, BigInt].check(_.euclideanRing)
+  laws[RingLaws, BigInt].check(_.euclideanFunction)
+  laws[RingLaws, BigInt].check(_.tDivMod)
 
   // let's limit our BigDecimal-related tests to the JVM for now.
   if (Platform.isJvm) {
@@ -241,6 +242,9 @@ class LawTests extends FunSuite with Configuration with Discipline {
   laws[OrderLaws, Array[Int]].check(_.partialOrder)
 
   // Rational tests do not return on Scala-js, so we make them JVM only.
-  if (Platform.isJvm) laws[RingLaws, Rat].check(_.field)
-  else ()
+  if (Platform.isJvm) {
+    laws[RingLaws, Rat].check(_.field)
+    laws[RingLaws, Rat].check(_.euclideanFunction)
+    laws[RingLaws, Rat].check(_.tDivMod)
+  } else ()
 }

--- a/laws/src/test/scala/algebra/laws/Rat.scala
+++ b/laws/src/test/scala/algebra/laws/Rat.scala
@@ -105,7 +105,7 @@ object Rat {
     } yield Rat(n, d))
 }
 
-class RatAlgebra extends Field[Rat] with Order[Rat] with Serializable {
+class RatAlgebra extends Field[Rat] with EuclideanFunction[Rat] with Order[Rat] with TDivMod[Rat] with Serializable {
 
   def compare(x: Rat, y: Rat): Int = x compare y
 
@@ -115,15 +115,23 @@ class RatAlgebra extends Field[Rat] with Order[Rat] with Serializable {
   def plus(a: Rat, b: Rat): Rat = a + b
   def negate(a: Rat): Rat = -a
   def times(a: Rat, b: Rat): Rat = a * b
+  def euclideanFunction(a: Rat) = if (isZero(a)) 0 else 1
   def quot(a: Rat, b: Rat) = a /~ b
   def mod(a: Rat, b: Rat) = a % b
   override def reciprocal(a: Rat): Rat = a.reciprocal
   def div(a: Rat, b: Rat): Rat = a / b
 
+  def tdiv(a: Rat, b: Rat): Rat = {
+    val toRound = a / b
+    Rat(toRound.num / toRound.den, 1)
+  }
+  def tmod(a: Rat, b: Rat): Rat = a + (-tdiv(a, b) * b)
+  override def abs(a: Rat): Rat = a.abs
+  def isWhole(a: Rat): Boolean = a.isWhole
+
   override def fromInt(n: Int): Rat = Rat(n)
 
-  def isWhole(a: Rat): Boolean = a.isWhole
   def ceil(a: Rat): Rat = a.ceil
-  def floor(a: Rat): Rat = a .floor
-  def round(a: Rat): Rat = a. round
+  def floor(a: Rat): Rat = a.floor
+  def round(a: Rat): Rat = a.round
 }


### PR DESCRIPTION
This is a basis for discussion, based on
https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/divmodnote-letter.pdf

This adds a definition of the dividend/modulo operation in ordered rings, distinct from the `quotmod` operation on EuclideanRing.

I added instances on `Rat` and `BigInt`, as representatives of an ordered field and integers. The instances for `Double` and `Long` should match their behavior, but testing Double/Long is difficult due to limited precision and overflow.

(I do not know if we should add these types at all, but we should be clear about what we mean by the "modulo" operation. Same for the `EuclideanFunction` typeclass, which is there to help us write complete tests.)
