### PR TITLE
Corrects EuclideanRing instances.

### DIFF
--- a/core/src/main/scala/algebra/instances/bigDecimal.scala
+++ b/core/src/main/scala/algebra/instances/bigDecimal.scala
@@ -21,13 +21,6 @@ class BigDecimalAlgebra extends Field[BigDecimal] with Serializable {
 
   def times(a: BigDecimal, b: BigDecimal): BigDecimal = a * b
   def div(a: BigDecimal, b: BigDecimal): BigDecimal = a / b
-  def quot(a: BigDecimal, b: BigDecimal) = a.quot(b)
-  def mod(a: BigDecimal, b: BigDecimal) = a.remainder(b)
-
-  override def quotmod(a: BigDecimal, b: BigDecimal) = {
-    val arr = a.bigDecimal.divideAndRemainder(b.bigDecimal)
-    (BigDecimal(arr(0)), BigDecimal(arr(1)))
-  }
 
   override def pow(a: BigDecimal, k: Int): BigDecimal = a pow k
 

--- a/core/src/main/scala/algebra/instances/double.scala
+++ b/core/src/main/scala/algebra/instances/double.scala
@@ -37,14 +37,6 @@ class DoubleAlgebra extends Field[Double] with Serializable {
   override def reciprocal(x: Double): Double = 1.0 / x
   override def pow(x: Double, y: Int): Double = Math.pow(x, y.toDouble)
 
-  def quot(x: Double, y: Double): Double = (x - (x % y)) / y
-  def mod(x: Double, y: Double): Double = x % y
-
-  override def quotmod(x: Double, y: Double): (Double, Double) = {
-    val m = x % y
-    ((x - m) / y, m)
-  }
-
   override def fromInt(x: Int): Double = x.toDouble
   override def fromDouble(x: Double): Double = x
 }

--- a/core/src/main/scala/algebra/instances/float.scala
+++ b/core/src/main/scala/algebra/instances/float.scala
@@ -38,14 +38,6 @@ class FloatAlgebra extends Field[Float] with Serializable {
   override def pow(x: Float, y: Int): Float =
     Math.pow(x.toDouble, y.toDouble).toFloat
 
-  def quot(x: Float, y: Float): Float = (x - (x % y)) / y
-  def mod(x: Float, y: Float): Float = x % y
-
-  override def quotmod(x: Float, y: Float): (Float, Float) = {
-    val m = x % y
-    ((x - m) / y, m)
-  }
-
   override def fromInt(x: Int): Float = x.toFloat
   override def fromDouble(x: Double): Float = x.toFloat
 }

--- a/core/src/main/scala/algebra/ring/Field.scala
+++ b/core/src/main/scala/algebra/ring/Field.scala
@@ -39,6 +39,13 @@ trait Field[@sp(Int, Long, Float, Double) A] extends Any with EuclideanRing[A] w
 
       if (a < 0) negate(unsigned) else unsigned
     }
+
+  /* On a field, all nonzero elements are invertible, so the remainder of the division
+     is always 0. */
+  def mod(a: A, b: A): A = zero
+  def quot(a: A, b: A): A = div(a, b)
+  override def quotmod(a: A, b: A): (A, A) = (div(a, b), zero)
+
 }
 
 trait FieldFunctions[F[T] <: Field[T]] extends EuclideanRingFunctions[F] with MultiplicativeGroupFunctions[F] {

--- a/laws/src/test/scala/algebra/laws/LawTests.scala
+++ b/laws/src/test/scala/algebra/laws/LawTests.scala
@@ -167,7 +167,7 @@ class LawTests extends FunSuite with Configuration with Discipline {
 
     // BigDecimal does have numerical errors, so we can't pass all of
     // the field laws.
-    laws[RingLaws, BigDecimal].check(_.euclideanRing)
+    laws[RingLaws, BigDecimal].check(_.ring)
   } else ()
 
   {

--- a/laws/src/test/scala/algebra/laws/Rat.scala
+++ b/laws/src/test/scala/algebra/laws/Rat.scala
@@ -115,8 +115,6 @@ class RatAlgebra extends Field[Rat] with Order[Rat] with Serializable {
   def plus(a: Rat, b: Rat): Rat = a + b
   def negate(a: Rat): Rat = -a
   def times(a: Rat, b: Rat): Rat = a * b
-  def quot(a: Rat, b: Rat) = a /~ b
-  def mod(a: Rat, b: Rat) = a % b
   override def reciprocal(a: Rat): Rat = a.reciprocal
   def div(a: Rat, b: Rat): Rat = a / b
 


### PR DESCRIPTION
The quotmod operation is uniquely defined in fields; this PR provides the correct implementation for Field.

This fixes the BigDecimal, Float, Double instances so that they are lawful (the test Rat instance was correct).

However, as we do not implement `euclideanFunction` in algebra, and the BigDecimal, Float and Double are partially tested, the incorrect behavior did not fail any tests --- and introducing failing tests requires quite a bit of infrastructure (see #172).

Note: there is a substantial impact on Spire as the operator `%` correspond to `EuclideanRing.mod`. Before the change, the incorrect instance gives `3.14 % 2 = 0.14`; this behavior is consistent with the scala stdlib syntax. After the change, `3.14 % 2 = 0`. Thus, `%` should be implemented using another type (see `tquotmod` in #172).

Note 2: the proof that `EuclideanRing.mod(x,y)=0` in a Field can be found in standard algebra textbooks. However, the jargon is quite hermetic. I can adapt an elementary proof from the law axioms if really needed.