### PR TITLE
Change CrossVersion.full to use CrossVersion.patch for Typelevel Scala compatibility.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -249,7 +249,7 @@ lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
       // in Scala 2.10, quasiquotes are provided by macro paradise
       case Some((2, 10)) =>
         Seq(
-          compilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full),
+          compilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.patch),
               "org.scalamacros" %% "quasiquotes" % "2.1.0-M5" cross CrossVersion.binary
         )
     }

--- a/build.sbt
+++ b/build.sbt
@@ -241,7 +241,7 @@ def crossVersionSharedSources() =
   }
 
 lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
-  libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
+  libraryDependencies += scalaOrganization.value % "scala-reflect" % scalaVersion.value % "provided",
   libraryDependencies ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       // if scala 2.11+ is used, quasiquotes are merged into scala-reflect


### PR DESCRIPTION
Including text from the issue at [typelevel/scala#135](https://github.com/typelevel/scala/issues/135): 

> To use Typelevel Scala versions which are not exactly aligned with the corresponding Lightbend Scala version (ie. because they include an additional -bin-patch-nnn suffix in their version) we need to modify project builds which use CrossVersion.full (which includes the suffix) to use CrossVersion.patch (which doesn't) where appropriate (eg. for macro-paradise and other compiler plugins).

Replaced the aforementioned, as well as updating the use of "org.scala-lang" to scalaOrganization.value in library dependencies.