### PR TITLE
Revert "Fix homepage"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Since the creation of Algebra, we have also decided to interoperate
 with the [Cats](http://github.com/typelevel/cats) project. Algebra and
 Cats interoperate using the *cats-kernel* module.
 
-See the [Algebra website](https://typelevel.github.io/algebra) for more information. The latest API docs are hosted at Algebra's [ScalaDoc index](https://typelevel.github.io/algebra/api/).
+See the [Algebra website](https://typelevel.org/algebra) for more information. The latest API docs are hosted at Algebra's [ScalaDoc index](https://typelevel.org/algebra/api/).
 
 ## getting algebra
 
@@ -89,7 +89,7 @@ requirements) you want generic parameters to possess.
 
 For a tour of the Algebraic structures that `algebra` offers, see the
 extensive
-[overview on the Algebra website](https://typelevel.github.com/algebra/typeclasses/overview.html).
+[overview on the Algebra website](https://typelevel.org/algebra/typeclasses/overview.html).
 
 ### Copyright and License
 

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ lazy val docSettings = Seq(
   micrositeDescription := "Algebraic Typeclasses for Scala.",
   micrositeAuthor := "Algebra's contributors",
   micrositeHighlightTheme := "atom-one-light",
-  micrositeHomepage := "https://typelevel.github.io/algebra/",
+  micrositeHomepage := "https://typelevel.org/algebra/",
   micrositeBaseUrl := "algebra",
   micrositeDocumentationUrl := "api/",
   micrositeGithubOwner := "typelevel",
@@ -159,10 +159,10 @@ lazy val benchmark = project.in(file("benchmark"))
   .dependsOn(coreJVM)
 
 lazy val publishSettings = Seq(
-  homepage := Some(url("http://typelevel.github.io/algebra")),
+  homepage := Some(url("http://typelevel.org/algebra")),
   licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT")),
   autoAPIMappings := true,
-  apiURL := Some(url("http://typelevel.github.io/algebra")),
+  apiURL := Some(url("https://typelevel.org/algebra/api/")),
 
   releaseCrossBuild := true,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,


### PR DESCRIPTION
Reverts typelevel/algebra#216

I'm not sure why the old links broke in the first place; regardless, they work again now.