### PR TITLE
Post-2.10 cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This repo represents an attempt to unify the basic algebraic type
 classes from [Spire](http://github.com/non/spire) and
 [Algebird](http://github.com/twitter/algebird). By targeting just
 these type classes, we will distribute an `algebra` package with no
-dependencies that works with Scala 2.10, 2.11, and 2.12, which can be
-shared by all Scala libraries interested in abstract algebra.
+dependencies (except for cats-kernel) that works with Scala 2.11 and
+2.12, which can be shared by all Scala libraries interested in abstract
+algebra.
 
 Since the creation of Algebra, we have also decided to interoperate
 with the [Cats](http://github.com/typelevel/cats) project. Algebra and
@@ -22,7 +23,7 @@ See the [Algebra website](https://typelevel.org/algebra) for more information. T
 
 ## getting algebra
 
-Algebra supports Scala 2.10, 2.11, and 2.12, and is available from
+Algebra supports Scala 2.11 and 2.12 and is available from
 Sonatype (and Maven Central). In addition to the JVM, Algebra also
 supports Scala.js.
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ To use algebra in your own projects, include this snippet in your
 `build.sbt` file:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "algebra" % "1.0.0"
+libraryDependencies += "org.typelevel" %% "algebra" % "1.0.1"
 ```
 
 If you want to use Algebra's laws, you can include those as well with
 this snippet:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "algebra-laws" % "1.0.0"
+libraryDependencies += "org.typelevel" %% "algebra-laws" % "1.0.1"
 ```
 
 ## what we have so far

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,6 @@ lazy val commonSettings = Seq(
     //"-Ywarn-value-discard", // fails with @sp on Unit
     "-Xfuture"
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 10)) => Seq.empty
     case Some((2, v)) if v <= 12 => Seq("-Ywarn-unused-import")
     case _ => Seq.empty
   }),
@@ -237,19 +236,7 @@ def crossVersionSharedSources() =
   }
 
 lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
-  libraryDependencies += scalaOrganization.value % "scala-reflect" % scalaVersion.value % "provided",
-  libraryDependencies ++= {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      // if scala 2.11+ is used, quasiquotes are merged into scala-reflect
-      case Some((2, scalaMajor)) if scalaMajor >= 11 => Seq()
-      // in Scala 2.10, quasiquotes are provided by macro paradise
-      case Some((2, 10)) =>
-        Seq(
-          compilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.patch),
-              "org.scalamacros" %% "quasiquotes" % "2.1.0-M5" cross CrossVersion.binary
-        )
-    }
-  }
+  libraryDependencies += scalaOrganization.value % "scala-reflect" % scalaVersion.value % "provided"
 )
 
 addCommandAlias("gitSnapshots", ";set version in ThisBuild := git.gitDescribedVersion.value.get + \"-SNAPSHOT\"")

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -4,13 +4,13 @@ title:  "Home"
 section: "home"
 ---
 
-Algebra unifies the basic algebraic type classes from [Spire](http://github.com/non/spire) and [Algebird](http://github.com/twitter/algebird). By targeting just these type classes `algebra` offers a package with no dependencies that works with Scala 2.10, 2.11, and 2.12, which can be shared by all Scala libraries interested in abstract algebra.
+Algebra unifies the basic algebraic type classes from [Spire](http://github.com/non/spire) and [Algebird](http://github.com/twitter/algebird). By targeting just these type classes `algebra` offers a package with no dependencies (except for cats-kernel) that works with Scala 2.11 and 2.12, which can be shared by all Scala libraries interested in abstract algebra.
 
 Algebra also interoperates with the [Cats](http://github.com/typelevel/cats) project. Algebra and Cats interoperate using the *cats-kernel* module.
 
 ## getting algebra
 
-Algebra supports Scala 2.10, 2.11, and 2.12, and is available from Sonatype (and Maven Central). In addition to the JVM, Algebra also supports Scala.js.
+Algebra supports Scala 2.11 and 2.12 and is available from Sonatype (and Maven Central). In addition to the JVM, Algebra also supports Scala.js.
 
 To use algebra in your own projects, include this snippet in your `build.sbt` file:
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -15,13 +15,13 @@ Algebra supports Scala 2.11 and 2.12 and is available from Sonatype (and Maven C
 To use algebra in your own projects, include this snippet in your `build.sbt` file:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "algebra" % "0.6.0"
+libraryDependencies += "org.typelevel" %% "algebra" % "1.0.1"
 ```
 
 If you want to use Algebra's laws, you can include those as well with this snippet:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "algebra-laws" % "0.6.0"
+libraryDependencies += "org.typelevel" %% "algebra-laws" % "1.0.1"
 ```
 
 ## what we have so far


### PR DESCRIPTION
1.0.1 dropped Scala 2.10 support. I've also clarified that in its current form Algebra is not completely dependency-less.